### PR TITLE
Fix an Xcode 6.3 compiler bug

### DIFF
--- a/SCScrollView/SCEasingFunction.m
+++ b/SCScrollView/SCEasingFunction.m
@@ -20,7 +20,7 @@
 
 + (instancetype)easingFunctionWithType:(SCEasingFunctionType)type
 {
-    return [[self alloc] initWithType:type];
+    return [[SCEasingFunction alloc] initWithType:type];
 }
 
 - (instancetype)initWithType:(SCEasingFunctionType)type


### PR DESCRIPTION
Hi,
This fixes a compiler error in Xcode 6.3. 
The compiler seems to bug one. It shouldn't but in the mean time, it is the only way to avoid a compiler error.
K.
